### PR TITLE
Allow building without installing global tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ To compile any changes into `glc-min.js` in the app directory, follow these step
 ### Install the build tools on your system:
 - [node.js](https://nodejs.org/)
 - [npm](https://www.npmjs.com/)
-- grunt-cli `npm install -g grunt-cli`
 
 ### optional:
 - [pandoc](http://pandoc.org/) if you will be building documentation.
@@ -21,10 +20,10 @@ To compile any changes into `glc-min.js` in the app directory, follow these step
 ### Add project dependencies:
 - `npm-install`
 
-### Grunt commands:
-- `grunt clean` deletes the `app` and `docs` directories.
-- `grunt build` builds the app into the `app` directory.
-- `grunt buildx` builds the app and launches it in the default browser.
-- `grunt docs` builds all the docs into the `docs` directory.
-- `grunt docsx` builds the docs and launches them in the default browser.
-- `grunt` cleans and builds both the app and the docs
+### Build commands:
+- `npm run clean` deletes the `app` and `docs` directories.
+- `npm run build` builds the app into the `app` directory.
+- `npm run buildx` or `npm start` builds the app and launches it in the default browser.
+- `npm run docs` builds all the docs into the `docs` directory.
+- `npm run docsx` builds the docs and launches them in the default browser.
+- `npm run default` cleans and builds both the app and the docs.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,13 @@
     "doc": "docs"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node -e \"require('grunt').tasks(['buildx']);\"",
+    "clean": "node -e \"require('grunt').tasks(['clean']);\"",
+    "build": "node -e \"require('grunt').tasks(['build']);\"",
+    "buildx": "node -e \"require('grunt').tasks(['buildx']);\"",
+    "docs": "node -e \"require('grunt').tasks(['buildx']);\"",
+    "default": "node -e \"require('grunt').tasks(['default']);\""
   },
   "author": "Keith Peters",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "clean": "node -e \"require('grunt').tasks(['clean']);\"",
     "build": "node -e \"require('grunt').tasks(['build']);\"",
     "buildx": "node -e \"require('grunt').tasks(['buildx']);\"",
-    "docs": "node -e \"require('grunt').tasks(['buildx']);\"",
+    "docs": "node -e \"require('grunt').tasks(['docs']);\"",
+    "docsx": "node -e \"require('grunt').tasks(['docsx']);\"",
     "default": "node -e \"require('grunt').tasks(['default']);\""
   },
   "author": "Keith Peters",


### PR DESCRIPTION
This pull requests allows developers to build this app using the locally-installed Grunt from node_modules, without installing Grunt globally on their systems--this will reduce the number of steps required to build the project.

Simply do `npm run ___` to run the Grunt build commands: no need to install other global tools, besides pandoc.